### PR TITLE
Up version of array-uniq

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "merge"
   ],
   "dependencies": {
-    "array-uniq": "^1.0.0"
+    "array-uniq": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
With NPM version 1.4.3, the resolved version of array-uniq was 1.0.0, which has a broken implementation of Set, which produces an empty array. When installing array-unique the correct version was resolved, but I'm thinking maybe the "^" was broken or something. At any rate, this ups the version to hopefully save others from my pain.
